### PR TITLE
Adding prompt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/loganfranken/ucsbdirectory#readme",
   "dependencies": {
+    "prompt": "^0.2.14",
     "request": "^2.67.0"
   }
 }


### PR DESCRIPTION
Forgot to save the dependency for prompt in the package.json.
